### PR TITLE
Migrate beacon spec into beacon-team repository from core schemas repository

### DIFF
--- a/schema/beacon.avdl
+++ b/schema/beacon.avdl
@@ -1,0 +1,170 @@
+@namespace("org.ga4gh.beacon")
+
+/**
+A Beacon is a web service for genetic data sharing that can be queried for 
+information about specific alleles.
+*/
+protocol BEACON {
+
+/**
+A request for information about a specific site
+*/
+record QueryResource {
+  /** 
+  The reference bases for this variant, starting from `position`, in the genome
+  described by the field `reference`. (see variants.avdl)
+   */
+  string referenceBases;
+
+  /** 
+  The bases that appear instead of the reference bases. (see variants.avdl)
+   */
+  string alternateBases;
+
+  /** The chromosome of the request */
+  string chromosome;
+
+  /** 0-based allele locus */
+  long position;
+
+  /** The version of the reference */
+  string reference;
+
+  /** The name of the targeted population */
+  union{ null, string } dataset = null;
+}
+
+/**
+ErrorResource
+*/
+record ErrorResource {
+  /** Error name/code, e.g. "bad_request" or "unauthorized". */
+  string name;
+
+  /** Error message. */
+  union{ null, string } description = null;
+}
+
+/**
+DataUseRequirementResource
+*/
+record DataUseRequirementResource {
+  /** Data Use requirement */
+  string name;
+
+  /** Description of Data Use requirement. */
+  union{ null, string } description = null;
+}
+
+/**
+DataUseResource
+*/
+record DataUseResource {
+  /** Data Use category.*/
+  string category;
+
+  /** Description of Data Use category. */
+  union{ null, string } description = null;
+
+  /** Data Use requirements. */
+  array<DataUseRequirementResource> requirements = [];
+}
+
+/**
+DataSetSizeResource
+*/
+record DataSizeResource {
+  /** Total number of variant positions in the data set */
+  int variants;
+
+  /** Total number of samples in the data set */
+  int samples;
+}
+
+/**
+DataSetResource
+*/
+record DataSetResource {
+  /** Dataset name */
+  string id;
+
+  /** Reference genome */
+  string reference;
+
+  /** Dataset description */
+  union{ null, string } description = null;
+
+  /** Dimensions of the data set. Should be provided if the beacon reports allele frequencies. */
+  union{ null, DataSizeResource } size = null;
+
+  /** Data use limitations, specified as a set of DataUseResource. */
+  array<DataUseResource> data_use = [];
+}
+
+/**
+BeaconInformationResource
+*/
+record BeaconInformationResource {
+  /** (Unique) beacon ID. Recommended pattern: [organization]-[beacon] (no special characters). */
+  string id;
+
+  /** Name of the owning organization. */
+  string organization;
+
+  /** Beacon description. */
+  string description;
+
+  /** Datasets served by the beacon. */
+  array<DataSetResource> datasets = [];
+
+  /** Beacon API version supported. */
+  string api;
+
+  /** URL to the homepage for this beacon. */
+  union{ null, string } homepage = null;
+
+  /** An email address for contact. */
+  union{ null, string } email = null;
+
+  /** Auth type. Expected value is OAUTH2. Defaults to NONE. */
+  union{ null, string } auth = null;
+
+  /** Examples of interesting queries, e.g. a few queries demonstrating different types of responses. */
+  union{ null, array<QueryResource> } queries = null;
+}
+
+/**
+The response to the Beacon query
+*/
+record ResponseResource {
+  /** Indicator of whether the beacon has observed the variant. */
+  union{ null, boolean } exists;
+
+  /** Frequency of this allele in the dataset. Between 0 and 1, inclusive. */
+  union{ null, double } frequency = null;
+
+  /** Number of observations of this allele in the dataset.  */
+  union{ null, int } observed = null;
+
+  /** Additional message. OK if request succeeded. */
+  union{ null, string } info = null;
+
+  /** Error details. Provided if a beacon encountered an error. */
+  union{ null, ErrorResource } err = null;
+}
+
+/**
+The response from the Beacon
+*/
+record BeaconResponseResource {
+  /** Beacon ID */
+  string beacon;
+
+  /** Query */
+  QueryResource query;
+
+  /** Response */
+  ResponseResource response;
+}
+
+}


### PR DESCRIPTION
Beacon is a demonstration project built on top of the core genomics APIs. In order to distinguish it as such, the Beacon schema should likely live outside the core API schemas. I propose moving the schema here, which will also allow better separation and commentation on Beacon project issues.