### PR TITLE
added alternateBasesInfo

### DIFF
--- a/src/main/resources/avro/beacon.avdl
+++ b/src/main/resources/avro/beacon.avdl
@@ -42,6 +42,15 @@ record BeaconAlleleRequest {
   */
   string alternateBases;
 
+  /**
+  Additional information for alternateBases. Based on VCF "INFO" field.
+
+  Accepted VCF INFO keys:
+  END, SVLEN, CIPOS, CIEND
+  key-value pairs are separated by a semi-colon as in VCF.
+  */ 
+  union{ null, string } alternateBasesInfo = null;
+
   /** Assembly identifier (GRC notation, e.g. `GRCh37`). */
   string assemblyId;
 


### PR DESCRIPTION
Extends support for structural variants and simple range queries.

Follow up of issue 20: https://github.com/ga4gh/beacon-team/issues/20