### PR TITLE
DUP,DEL and required positional parameters

### DIFF
--- a/src/main/proto/ga4gh/beacon.proto
+++ b/src/main/proto/ga4gh/beacon.proto
@@ -9,44 +9,78 @@ message BeaconAlleleRequest {
   // Reference name (chromosome).
   //
   // Accepted values: 1-22, X, Y.
+  // Required.
   string reference_name = 1;
 
-  // Position, allele locus (0-based).
+  // Position, genomic locus (0-based). This is represented as a list with
+  // 1..2 elements.
+  // For the querying of variants with known exact position and composition,
+  // the use of a single start position value is sufficient.
+  // For querying imprecise positions (e.g. identifying all structural variants
+  // starting in a genomic region), 2 values indicating start and end of this
+  // region are required.
   //
-  // Accepted values: non-negative integers smaller than reference length.
-  int64 start = 2;
+  // Accepted values: 1 or 2 non-negative integers smaller than reference length.
+  // Required.
+  repeated int64 start = 2;
+
+  // Position of the end of avariant as genomic locus (0-based). This is
+  // represented as a list with of 0..2 elements.
+  // A query against variants with known exact position and composition (e.g.
+  // single base SNP), no "end" parameters have to be specified.
+  // For the query against  e.g. a structural variant with known exact end
+  // position, the use of a single end value is possible.
+  // For querying imprecise positions (e.g. identifying all structural variants
+  // starting in a genomic region), 2 values indicating start and end of the
+  // assumed end are required.
+  //
+  // Accepted values: 0, 1 or 2 non-negative integers smaller or equal to the
+  // reference length.
+  // Optional.
+  repeated int64 end = 3;
 
   // Reference bases for this variant (starting from `start`).
   //
   // Accepted values: see the REF field in VCF 4.2 specification
   // (https://samtools.github.io/hts-specs/VCFv4.2.pdf).
-  string reference_bases = 3;
+  // Optional.
+  string reference_bases = 4;
 
   // The bases that appear instead of the reference bases.
   //
   // Accepted values: see the ALT field in VCF 4.2 specification
   // (https://samtools.github.io/hts-specs/VCFv4.2.pdf).
-  string alternate_bases = 4;
+  // Optional (either "alternate_bases" or "variant_type" is required)
+  string alternate_bases = 5;
+
+  // The "variant_type" is used to denote e.g. structural variants.
+  // Examples:
+  //   DUP  : duplication of sequence following "start"; not necessarily in situ
+  //   DEL  : deletion of sequence following "start"
+  // Optional (either "alternate_bases" or "variant_type" is required)
+  string variant_type = 6;
 
   // Assembly identifier (GRC notation, e.g. `GRCh37`).
-  string assembly_id = 5;
+  string assembly_id = 6;
 
   // Identifiers of datasets, as defined in `BeaconDataset`.
   //
   // If this field is null/not specified, all datasets should be queried.
-  repeated string dataset_ids = 6;
+  // Optional.
+  repeated string dataset_ids = 7;
 
   // Indicator of whether responses for individual datasets
   // (`datasetAlleleResponses`) should be included (not null) in the response
   // (`BeaconAlleleResponse`) to this request.
   //
   // If null (not specified), the default value of false is assumed.
-  bool include_dataset_responses = 7;
+  // Optional.
+  bool include_dataset_responses = 8;
 }
 
 // Dataset of a beacon.
 message BeaconDataset {
-  // Unique identifier of the dataset. 
+  // Unique identifier of the dataset.
   string id = 1;
 
   // Name of the dataset.
@@ -55,49 +89,49 @@ message BeaconDataset {
   // Description of the dataset.
   string description = 3;
 
-  // Assembly identifier (GRC notation, e.g. `GRCh37`). 
+  // Assembly identifier (GRC notation, e.g. `GRCh37`).
   string assembly_id = 4;
 
-  // The time the dataset was created (ISO 8601 format). 
+  // The time the dataset was created (ISO 8601 format).
   string create_date_time = 5;
 
-  // The time the dataset was updated in (ISO 8601 format). 
+  // The time the dataset was updated in (ISO 8601 format).
   string update_date_time = 6;
 
-  // Version of the dataset. 
+  // Version of the dataset.
   string version = 7;
 
-  // Total number of variants in the dataset. 
+  // Total number of variants in the dataset.
   int64 variant_count = 8;
 
-  // Total number of calls in the dataset. 
+  // Total number of calls in the dataset.
   int64 call_count = 9;
 
-  // Total number of samples in the dataset. 
+  // Total number of samples in the dataset.
   int64 sample_count = 10;
 
-  // URL to an external system providing more dataset information (RFC 3986 format). 
+  // URL to an external system providing more dataset information (RFC 3986 format).
   string external_url = 11;
 
   // A map of additional information.
   map<string, string> info = 12;
 }
 
-// Organization owning a beacon. 
+// Organization owning a beacon.
 message BeaconOrganization {
-  // Unique identifier of the organization. 
+  // Unique identifier of the organization.
   string id = 1;
 
-  // Name of the organization. 
+  // Name of the organization.
   string name = 2;
 
-  // Description of the organization. 
+  // Description of the organization.
   string description = 3;
 
-  // Address of the organization. 
+  // Address of the organization.
   string address = 4;
 
-  // URL of the website of the organization (RFC 3986 format). 
+  // URL of the website of the organization (RFC 3986 format).
   string welcome_url = 5;
 
   // URL with the contact for the beacon operator/maintainer, e.g. link to
@@ -111,37 +145,37 @@ message BeaconOrganization {
   map<string, string> info = 12;
 }
 
-// Beacon. 
+// Beacon.
 message Beacon {
-  // Unique identifier of the beacon. 
+  // Unique identifier of the beacon.
   string id = 1;
 
-  // Name of the beacon. 
+  // Name of the beacon.
   string name = 2;
 
-  // Version of the API provided by the beacon. 
+  // Version of the API provided by the beacon.
   string api_version = 3;
 
-  // Organization owning the beacon. 
+  // Organization owning the beacon.
   BeaconOrganization organization = 4;
 
-  // Description of the beacon. 
+  // Description of the beacon.
   string description = 5;
 
-  // Version of the beacon. 
+  // Version of the beacon.
   string version = 6;
 
-  // URL to the welcome page for this beacon (RFC 3986 format). 
+  // URL to the welcome page for this beacon (RFC 3986 format).
   string welcome_url = 7;
 
   // Alternative URL to the API, e.g. a restricted version of this beacon
   // (RFC 3986 format).
   string alternative_url = 8;
 
-  // The time the beacon was created (ISO 8601 format). 
+  // The time the beacon was created (ISO 8601 format).
   string create_date_time = 9;
 
-  // The time the beacon was updated in (ISO 8601 format). 
+  // The time the beacon was updated in (ISO 8601 format).
   string update_date_time = 10;
 
   // Datasets served by the beacon. Any beacon should specify at least one
@@ -156,18 +190,18 @@ message Beacon {
   map<string, string> info = 13;
 }
 
-// Beacon-specific error representing an unexpected problem. 
+// Beacon-specific error representing an unexpected problem.
 message BeaconError {
-  // Numeric error code. 
+  // Numeric error code.
   int32 error_code = 1;
 
-  // Error message. 
+  // Error message.
   string message = 2;
 }
 
-// Dataset's response to a query for information about a specific allele. 
+// Dataset's response to a query for information about a specific allele.
 message BeaconDatasetAlleleResponse {
-  // Identifier of the dataset, as defined in `BeaconDataset`. 
+  // Identifier of the dataset, as defined in `BeaconDataset`.
   string dataset_id = 1;
 
   // Indicator of whether the given allele was observed in the dataset.
@@ -182,19 +216,19 @@ message BeaconDatasetAlleleResponse {
   // `exists` has to be null.
   BeaconError error = 3;
 
-  // Frequency of this allele in the dataset. Between 0 and 1, inclusive. 
+  // Frequency of this allele in the dataset. Between 0 and 1, inclusive.
   double frequency = 4;
 
-  // Number of variants matching the allele request in the dataset. 
+  // Number of variants matching the allele request in the dataset.
   int64 variant_count = 5;
 
-  // Number of calls matching the allele request in the dataset. 
+  // Number of calls matching the allele request in the dataset.
   int64 call_count = 6;
 
-  // Number of samples matching the allele request in the dataset. 
+  // Number of samples matching the allele request in the dataset.
   int64 sample_count = 7;
 
-  // Additional note or description of the response. 
+  // Additional note or description of the response.
   string note = 8;
 
   // URL to an external system, such as a secured beacon or a system providing
@@ -205,9 +239,9 @@ message BeaconDatasetAlleleResponse {
   map<string, string> info = 13;
 }
 
-// Beacon's response to a query for information about a specific allele. 
+// Beacon's response to a query for information about a specific allele.
 message BeaconAlleleResponse {
-  // Identifier of the beacon, as defined in `Beacon`. 
+  // Identifier of the beacon, as defined in `Beacon`.
   string beacon_id = 1;
 
   // Indicator of whether the given allele was observed in any of the datasets
@@ -222,8 +256,8 @@ message BeaconAlleleResponse {
   // This should be non-null in exceptional situations only, in which case
   // `exists` has to be null.
   BeaconError error = 3;
-  
-  // Allele request as interpreted by the beacon. 
+
+  // Allele request as interpreted by the beacon.
   BeaconAlleleRequest allele_request = 4;
 
   // Indicator of whether the given allele was observed in individual datasets.

--- a/src/main/proto/ga4gh/beacon.proto
+++ b/src/main/proto/ga4gh/beacon.proto
@@ -34,7 +34,7 @@ message BeaconAlleleRequest {
   //   - single or douple sided precise matches can be achieved by setting
   //     start_min = start_max XOR end_min = end_max
   //
-  int64 start = 2;  // required
+  int64 start = 2;
 
   int64 start_min = 3;
 
@@ -65,6 +65,8 @@ message BeaconAlleleRequest {
   //   DUP  : duplication of sequence following "start"; not necessarily in situ
   //   DEL  : deletion of sequence following "start"
   // Optional (either "alternate_bases" or "variant_type" is required)
+  // TODO: Evaluate implementation of variant_type as ontology term
+  // (e.g. SO - Sequence Ontology or general GA4GH style OntologyTerm object).
   string variant_type = 10;
 
   // Assembly identifier (GRC notation, e.g. `GRCh37`).

--- a/src/main/proto/ga4gh/beacon.proto
+++ b/src/main/proto/ga4gh/beacon.proto
@@ -65,8 +65,6 @@ message BeaconAlleleRequest {
   //   DUP  : duplication of sequence following "start"; not necessarily in situ
   //   DEL  : deletion of sequence following "start"
   // Optional (either "alternate_bases" or "variant_type" is required)
-  // TODO: Evaluate implementation of variant_type as ontology term
-  // (e.g. SO - Sequence Ontology or general GA4GH style OntologyTerm object).
   string variant_type = 10;
 
   // Assembly identifier (GRC notation, e.g. `GRCh37`).

--- a/src/main/proto/ga4gh/beacon.proto
+++ b/src/main/proto/ga4gh/beacon.proto
@@ -50,7 +50,7 @@ message BeaconAlleleRequest {
   //
   // Accepted values: see the REF field in VCF 4.2 specification
   // (https://samtools.github.io/hts-specs/VCFv4.2.pdf).
-  // Optional.
+  // Required if none of end | end_min | end_max parameters is given.
   string reference_bases = 8;
 
   // The bases that appear instead of the reference bases.

--- a/src/main/proto/ga4gh/beacon.proto
+++ b/src/main/proto/ga4gh/beacon.proto
@@ -12,62 +12,69 @@ message BeaconAlleleRequest {
   // Required.
   string reference_name = 1;
 
-  // Position, genomic locus (0-based). This is represented as a list with
-  // 1..2 elements.
-  // For the querying of variants with known exact position and composition,
-  // the use of a single start position value is sufficient.
-  // For querying imprecise positions (e.g. identifying all structural variants
-  // starting in a genomic region), 2 values indicating start and end of this
-  // region are required.
+  // Position, genomic locus (0-based).
   //
-  // Accepted values: 1 or 2 non-negative integers smaller than reference length.
-  // Required.
-  repeated int64 start = 2;
+  // start only:
+  //   - for single positions, e.g. the start of a specified sequence alteration
+  //     where the size is given through the specified alternate_bases
+  //   - typical use are queries for SNV and small InDels
+  //   - the use of "start" without an "end" parameter requires the use of
+  //     "reference_bases"
+  //
+  // start and end:
+  //   - special use case for exactly determined structural changes
+  //   - TODO: may be used to determine an interval in which a specific sequence
+  //     variant (such as normally spefified by a single start parameter) can
+  //     occur (e.g. an abberrant stop codon)
+  //
+  // start_min + start_max + end_min + end_max
+  //   - for querying imprecise positions (e.g. identifying all structural
+  //     variants starting anywhere between start_min <-> start_max, and ending
+  //     anywhere between end_min <-> end_max
+  //   - single or douple sided precise matches can be achieved by setting
+  //     start_min = start_max XOR end_min = end_max
+  //
+  int64 start = 2;  // required
 
-  // Position of the end of avariant as genomic locus (0-based). This is
-  // represented as a list with of 0..2 elements.
-  // A query against variants with known exact position and composition (e.g.
-  // single base SNP), no "end" parameters have to be specified.
-  // For the query against  e.g. a structural variant with known exact end
-  // position, the use of a single end value is possible.
-  // For querying imprecise positions (e.g. identifying all structural variants
-  // starting in a genomic region), 2 values indicating start and end of the
-  // assumed end are required.
-  //
-  // Accepted values: 0, 1 or 2 non-negative integers smaller or equal to the
-  // reference length.
-  // Optional.
-  repeated int64 end = 3;
+  int64 start_min = 3;
+
+  int64 start_max = 4;
+
+  int64 end = 5;
+
+  int64 end_min = 6;
+
+  int64 end_max = 7;
 
   // Reference bases for this variant (starting from `start`).
   //
   // Accepted values: see the REF field in VCF 4.2 specification
   // (https://samtools.github.io/hts-specs/VCFv4.2.pdf).
   // Optional.
-  string reference_bases = 4;
+  string reference_bases = 8;
 
   // The bases that appear instead of the reference bases.
   //
   // Accepted values: see the ALT field in VCF 4.2 specification
   // (https://samtools.github.io/hts-specs/VCFv4.2.pdf).
   // Optional (either "alternate_bases" or "variant_type" is required)
-  string alternate_bases = 5;
+  string alternate_bases = 9;
 
   // The "variant_type" is used to denote e.g. structural variants.
   // Examples:
   //   DUP  : duplication of sequence following "start"; not necessarily in situ
   //   DEL  : deletion of sequence following "start"
   // Optional (either "alternate_bases" or "variant_type" is required)
-  string variant_type = 6;
+  string variant_type = 10;
 
   // Assembly identifier (GRC notation, e.g. `GRCh37`).
-  string assembly_id = 6;
+  string assembly_id = 11;
 
   // Identifiers of datasets, as defined in `BeaconDataset`.
   //
   // If this field is null/not specified, all datasets should be queried.
   // Optional.
-  repeated string dataset_ids = 7;
+  repeated string dataset_ids = 12;
 
   // Indicator of whether responses for individual datasets
   // (`datasetAlleleResponses`) should be included (not null) in the response
@@ -75,7 +82,7 @@ message BeaconAlleleRequest {
   //
   // If null (not specified), the default value of false is assumed.
   // Optional.
-  bool include_dataset_responses = 8;
+  bool include_dataset_responses = 13;
 }
 
 // Dataset of a beacon.


### PR DESCRIPTION
This PR implements both the attributes for querying a subset of structural variants, such as currently possibly represented through the GA4GH [variants schema](https://github.com/ga4gh/ga4gh-schemas/blob/master/src/main/proto/ga4gh/variants.proto#L200), as well as the `start[1..2]`, `end[0..2]` modifications to allow matching variants of imprecise alert, end and sequence composition.

The need for these changes as well as possible ways to implement them have been discussed previously:

* [Document about range match implementation](https://docs.google.com/document/d/1uePLlLMl0FzxZxDrsF9IxsC2nYvZ84029fzUD1ULNWI/edit#heading=h.hprckfsqtmkh) using start, end intervals
* Previous Github issues https://github.com/ga4gh/beacon-team/issues/20, https://github.com/ga4gh/beacon-team/issues/65, https://github.com/ga4gh/beacon-team/issues/80

Also, the moving ahead with structural variant definitions in both schemas and Beacon has been discussed with the VMC team (@reece, @sarahhunt), who at the present focus on the representation of precise variants.

Technical notes:

* This changes the index numbers of the develop-proto branch; however, in this case it seems acceptable since proto had not been implemented as master.
* There has been no change to `beacon_server.proto`