### PR TITLE
BeaconCNVrequest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ target/
 #********** IntelliJ files ******
 *.iml
 
+#********** Dependency files ********
+src/avro-schema-test-base

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+- 2.7
+branches:
+  only:
+  - master
+  - develop
+script:
+- nosetests -v $VIRTUAL_ENV/src/avro-schema-test-base
+notifications:
+  slack:
+    secure: RmyIMB6tA868r+dHECJ566r0+TCB6pHvg9PygNiM5ye+iX4I+CFKMoGzjeMVtuLI80MSzzoaB+PU6TczlhzdbJBALqiV74AQCoNGqswJzJCkJX7HDGk8LVFSsnpwClRLLLVgvBApGDS0ViRfGqsew8CJ8VR5BMDiU53z3Of4JHc=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Beacon Schemas
+# Beacon Schemas [![Build Status](https://travis-ci.org/ga4gh/beacon-team.svg?branch=develop)](https://travis-ci.org/ga4gh/beacon-team) [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/ga4gh/beacon-team/develop/LICENSE) [![Slack](https://beacon-team-slackin.herokuapp.com/badge.svg)](https://beacon-team-slackin.herokuapp.com/)
 
 ## What is a Beacon?
 
@@ -16,9 +16,17 @@ A list of related tools and projects developed by the community is maintained on
 
 Guidelines for contributing to this repository are listed in the [CONTRIBUTING.md](CONTRIBUTING.md) document.
 
-## License
+## How to build
 
-See the [LICENSE](LICENSE) file.
+Prerequisites: Maven 3+, Java 1.6+.
+
+To generate Java code, run `mvn package` and check the output in the `target` directory. 
+
+## How to test
+
+Prerequisites: Python 2.7 (incl. Pip 7+).
+
+Install dependencies with `pip install -r requirements.txt`. To run the test suite, use `nosetests -v`.
 
 ## More information
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+-e git+https://github.com/mcupak/avro-schema-test-base.git@v0.1.0#egg=avro-schema-test-base
+avro==1.8.0
+humanize==0.5.1
+nose==1.3.7
+requests==2.12.3

--- a/src/main/proto/ga4gh/beacon.proto
+++ b/src/main/proto/ga4gh/beacon.proto
@@ -44,9 +44,67 @@ message BeaconAlleleRequest {
   bool include_dataset_responses = 7;
 }
 
+// A BeaconCNVrequest queries a variant resource for the occurrence of copy
+// number variation/aberration (CNV) events.
+// In most instances, these events will be "imprecise", i.e. they will have
+// varying start and end positions, and queries will be addressed e.g. to
+// find all deletion variants overlapping with the CDR of a gene of interest.
+//
+// ____S-----S_____________E------E_______
+// ######+++++++++++++++++++++++##########
+// ###########+++++++++++++++#############
+//
+// ____S________________________E_________
+// ####++++++++++++++++++++++++++#########
+//
+// S----------------------S_____E_________
+// ################++++++++++++++#########
+//
+message BeaconCNVrequest {
+
+  // Reference name (chromosome).
+  //
+  // Accepted values: 1-22, X, Y.
+  // Required.
+  string reference_name = 1;
+
+  // Position, genomic locus (0-based). This is represented as a list with
+  // 1..2 elements.
+  // For the querying of variants with known exact position,
+  // the use of a single start position value is sufficient.
+  // For querying imprecise positions (e.g. identifying all structural variants
+  // starting in a genomic region), 2 values indicating start and end of this
+  // region are required.
+  //
+  // Accepted values: 1 or 2 non-negative integers smaller than reference length.
+  // Required.
+  repeated int64 start = 2;
+
+  // Position of the end of avariant as genomic locus (0-based). This is
+  // represented as a list with of 0..2 elements.
+  // For the query against  e.g. a structural variant with known exact end
+  // position, the use of a single end value is possible.
+  // For querying imprecise positions (e.g. identifying all structural variants
+  // starting in a genomic region), 2 values indicating start and end of the
+  // assumed end are required.
+  //
+  // Accepted values: 1 or 2 non-negative integers smaller or equal to the
+  // reference length.
+  // Required.
+  repeated int64 end = 3;
+
+  // The "variant_type" is used to denote e.g. structural variants.
+  // Examples:
+  //   DUP  : duplication of sequence following "start"; not necessarily in situ
+  //   DEL  : deletion of sequence following "start"
+  // Required.
+  string variant_type = 4;
+
+}
+
 // Dataset of a beacon.
 message BeaconDataset {
-  // Unique identifier of the dataset. 
+  // Unique identifier of the dataset.
   string id = 1;
 
   // Name of the dataset.
@@ -55,49 +113,49 @@ message BeaconDataset {
   // Description of the dataset.
   string description = 3;
 
-  // Assembly identifier (GRC notation, e.g. `GRCh37`). 
+  // Assembly identifier (GRC notation, e.g. `GRCh37`).
   string assembly_id = 4;
 
-  // The time the dataset was created (ISO 8601 format). 
+  // The time the dataset was created (ISO 8601 format).
   string create_date_time = 5;
 
-  // The time the dataset was updated in (ISO 8601 format). 
+  // The time the dataset was updated in (ISO 8601 format).
   string update_date_time = 6;
 
-  // Version of the dataset. 
+  // Version of the dataset.
   string version = 7;
 
-  // Total number of variants in the dataset. 
+  // Total number of variants in the dataset.
   int64 variant_count = 8;
 
-  // Total number of calls in the dataset. 
+  // Total number of calls in the dataset.
   int64 call_count = 9;
 
-  // Total number of samples in the dataset. 
+  // Total number of samples in the dataset.
   int64 sample_count = 10;
 
-  // URL to an external system providing more dataset information (RFC 3986 format). 
+  // URL to an external system providing more dataset information (RFC 3986 format).
   string external_url = 11;
 
   // A map of additional information.
   map<string, string> info = 12;
 }
 
-// Organization owning a beacon. 
+// Organization owning a beacon.
 message BeaconOrganization {
-  // Unique identifier of the organization. 
+  // Unique identifier of the organization.
   string id = 1;
 
-  // Name of the organization. 
+  // Name of the organization.
   string name = 2;
 
-  // Description of the organization. 
+  // Description of the organization.
   string description = 3;
 
-  // Address of the organization. 
+  // Address of the organization.
   string address = 4;
 
-  // URL of the website of the organization (RFC 3986 format). 
+  // URL of the website of the organization (RFC 3986 format).
   string welcome_url = 5;
 
   // URL with the contact for the beacon operator/maintainer, e.g. link to
@@ -111,37 +169,37 @@ message BeaconOrganization {
   map<string, string> info = 12;
 }
 
-// Beacon. 
+// Beacon.
 message Beacon {
-  // Unique identifier of the beacon. 
+  // Unique identifier of the beacon.
   string id = 1;
 
-  // Name of the beacon. 
+  // Name of the beacon.
   string name = 2;
 
-  // Version of the API provided by the beacon. 
+  // Version of the API provided by the beacon.
   string api_version = 3;
 
-  // Organization owning the beacon. 
+  // Organization owning the beacon.
   BeaconOrganization organization = 4;
 
-  // Description of the beacon. 
+  // Description of the beacon.
   string description = 5;
 
-  // Version of the beacon. 
+  // Version of the beacon.
   string version = 6;
 
-  // URL to the welcome page for this beacon (RFC 3986 format). 
+  // URL to the welcome page for this beacon (RFC 3986 format).
   string welcome_url = 7;
 
   // Alternative URL to the API, e.g. a restricted version of this beacon
   // (RFC 3986 format).
   string alternative_url = 8;
 
-  // The time the beacon was created (ISO 8601 format). 
+  // The time the beacon was created (ISO 8601 format).
   string create_date_time = 9;
 
-  // The time the beacon was updated in (ISO 8601 format). 
+  // The time the beacon was updated in (ISO 8601 format).
   string update_date_time = 10;
 
   // Datasets served by the beacon. Any beacon should specify at least one
@@ -156,18 +214,18 @@ message Beacon {
   map<string, string> info = 13;
 }
 
-// Beacon-specific error representing an unexpected problem. 
+// Beacon-specific error representing an unexpected problem.
 message BeaconError {
-  // Numeric error code. 
+  // Numeric error code.
   int32 error_code = 1;
 
-  // Error message. 
+  // Error message.
   string message = 2;
 }
 
-// Dataset's response to a query for information about a specific allele. 
+// Dataset's response to a query for information about a specific allele.
 message BeaconDatasetAlleleResponse {
-  // Identifier of the dataset, as defined in `BeaconDataset`. 
+  // Identifier of the dataset, as defined in `BeaconDataset`.
   string dataset_id = 1;
 
   // Indicator of whether the given allele was observed in the dataset.
@@ -182,19 +240,19 @@ message BeaconDatasetAlleleResponse {
   // `exists` has to be null.
   BeaconError error = 3;
 
-  // Frequency of this allele in the dataset. Between 0 and 1, inclusive. 
+  // Frequency of this allele in the dataset. Between 0 and 1, inclusive.
   double frequency = 4;
 
-  // Number of variants matching the allele request in the dataset. 
+  // Number of variants matching the allele request in the dataset.
   int64 variant_count = 5;
 
-  // Number of calls matching the allele request in the dataset. 
+  // Number of calls matching the allele request in the dataset.
   int64 call_count = 6;
 
-  // Number of samples matching the allele request in the dataset. 
+  // Number of samples matching the allele request in the dataset.
   int64 sample_count = 7;
 
-  // Additional note or description of the response. 
+  // Additional note or description of the response.
   string note = 8;
 
   // URL to an external system, such as a secured beacon or a system providing
@@ -205,9 +263,9 @@ message BeaconDatasetAlleleResponse {
   map<string, string> info = 13;
 }
 
-// Beacon's response to a query for information about a specific allele. 
+// Beacon's response to a query for information about a specific allele.
 message BeaconAlleleResponse {
-  // Identifier of the beacon, as defined in `Beacon`. 
+  // Identifier of the beacon, as defined in `Beacon`.
   string beacon_id = 1;
 
   // Indicator of whether the given allele was observed in any of the datasets
@@ -222,8 +280,8 @@ message BeaconAlleleResponse {
   // This should be non-null in exceptional situations only, in which case
   // `exists` has to be null.
   BeaconError error = 3;
-  
-  // Allele request as interpreted by the beacon. 
+
+  // Allele request as interpreted by the beacon.
   BeaconAlleleRequest allele_request = 4;
 
   // Indicator of whether the given allele was observed in individual datasets.

--- a/src/main/proto/ga4gh/beacon.proto
+++ b/src/main/proto/ga4gh/beacon.proto
@@ -50,15 +50,18 @@ message BeaconAlleleRequest {
 // varying start and end positions, and queries will be addressed e.g. to
 // find all deletion variants overlapping with the CDR of a gene of interest.
 //
-// ____S-----S_____________E------E_______
-// ######+++++++++++++++++++++++##########
-// ###########+++++++++++++++#############
+//           11111111112222222222333333333
+// 012345678901234567890123456789012345678
 //
-// ____S________________________E_________
-// ####++++++++++++++++++++++++++#########
+// ____S-----S_____________E------E_______   start[3,10], end[23,31]
+//  #####+++++++++++++++++++++++##########
+//  #########++++++++++++++++#############
 //
-// S----------------------S_____E_________
-// ################++++++++++++++#########
+// ____S________________________E_________   start[3], end[28]
+//  ###++++++++++++++++++++++++++#########
+//
+// S----------------------S_____E_________   start[0,23], end[28]
+//  ###############++++++++++++++#########
 //
 message BeaconCNVrequest {
 
@@ -69,7 +72,7 @@ message BeaconCNVrequest {
   string reference_name = 1;
 
   // Position, genomic locus (0-based). This is represented as a list with
-  // 1..2 elements.
+  // 1 or 2 elements.
   // For the querying of variants with known exact position,
   // the use of a single start position value is sufficient.
   // For querying imprecise positions (e.g. identifying all structural variants
@@ -81,16 +84,18 @@ message BeaconCNVrequest {
   repeated int64 start = 2;
 
   // Position of the end of avariant as genomic locus (0-based). This is
-  // represented as a list with of 0..2 elements.
+  // represented as a list with of 0, 1 or 2 elements.
   // For the query against  e.g. a structural variant with known exact end
   // position, the use of a single end value is possible.
   // For querying imprecise positions (e.g. identifying all structural variants
   // starting in a genomic region), 2 values indicating start and end of the
   // assumed end are required.
   //
-  // Accepted values: 1 or 2 non-negative integers smaller or equal to the
+  // Accepted values: 0, 1 or 2 non-negative integers smaller or equal to the
   // reference length.
-  // Required.
+  // Optional; if no value is provided, the server should use the value(s) from
+  // the "start" attribute (i.e. processing the request as for a variant
+  // contained in the range given by the start interval).
   repeated int64 end = 3;
 
   // The "variant_type" is used to denote e.g. structural variants.


### PR DESCRIPTION
This is an alternative to PR #94. Here, the BeaconAlleleRequest remains untouched; instead, BeaconCNVrequest implements a separate message only addressing the first type of structural variants (CNV - DUP, DEL).