### PR TITLE
Generate separate Java classes

### DIFF
--- a/src/main/proto/ga4gh/beacon.proto
+++ b/src/main/proto/ga4gh/beacon.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package ga4gh;
 
+option java_package = "org.ga4gh.beacon";
+option java_multiple_files = true;
+
 // A Beacon is a web service for genetic data sharing that can be queried for
 // information about specific alleles.
 // Query for information about a specific allele. Based on ga4gh variant.

--- a/src/main/proto/ga4gh/beacon_service.proto
+++ b/src/main/proto/ga4gh/beacon_service.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package ga4gh;
 
+option java_package = "org.ga4gh.beacon";
+option java_multiple_files = true;
+
 import "ga4gh/beacon.proto";
 import "google/protobuf/empty.proto";
 


### PR DESCRIPTION
Changes the Java configuration so that top-level messages, enums, and services are defined at the package level, rather than inside an outer class. This is more convenient and common.